### PR TITLE
fix: gracefully handle groups missing from source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-user-sync-tool",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "sync snyk org users from an external source",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -96,7 +96,7 @@ export async function processMemberships() {
             );
           } else {
             utils.log(`${gmd.groupName} not found in source, skipping...`);
-            break;
+            continue;
           }
         } else {
           const sourceMembershipsForGroup = {
@@ -113,7 +113,7 @@ export async function processMemberships() {
             );
           } else {
             utils.log(`${gmd.groupName} not found in source, skipping...`);
-            break;
+            continue;
           }
         }
 


### PR DESCRIPTION
do not stop processing groups when 1 is found to be missing from the source data