### PR TITLE
feat: add flag --invite-to-all-orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,23 @@ Usage: snyk-user-sync-tool [OPTIONS]
                 SaaS is used.
 
 Options:
-  --version          Show version number                               [boolean]
-  --add-new          add memberships if they are found in the
-                     membership-file and are not in Snyk
-  --delete-missing   delete memberships from Snyk if they are found
-                     to be missing from the membership-file (use with caution)
-  --v2               use v2 file format
-  --membership-file  path to membership file
-                     if not specified, taken from SNYK_IAM_MEMBERSHIP_FILE
-  --api-keys         list of api keys per group
-                     if not specified, taken from SNYK_IAM_API_KEYS
-  --dry-run          print/log the execution plan without making any updates to
-                     Snyk
-  --debug            enable debug mode                                 [boolean]
-  --help             Show help                                         [boolean]
+  --version             Show version number                            [boolean]
+  --add-new             add memberships if they are found in the
+                        membership-file and are not in Snyk
+  --delete-missing      delete memberships from Snyk if they are found
+                        to be missing from the membership-file (use with
+                        caution)
+  --v2                  use v2 file format
+  --membership-file     path to membership file
+                        if not specified, taken from SNYK_IAM_MEMBERSHIP_FILE
+  --api-keys            list of api keys per group
+                        if not specified, taken from SNYK_IAM_API_KEYS
+  --dry-run             print/log the execution plan without making any updates
+                        to Snyk
+  --invite-to-all-orgs  send new users an invite to every org, rather than only
+                        the first
+  --debug               enable debug mode                              [boolean]
+  --help                Show help                                      [boolean]
 ```
 __Example__:
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-user-sync-tool",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "sync snyk org users from an external source",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -11,6 +11,7 @@ export const VALID_ROLES_FILE = BASE_DIR.concat('conf/roles.json');
 export const LOG_LIMIT = 25;
 export var DRY_RUN_FLAG: boolean = false;
 export var ADD_NEW_FLAG: boolean = false;
+export var INVITE_TO_ALL_ORGS_FLAG: boolean = false;
 export var DELETE_MISSING_FLAG: boolean = false;
 export var V2_FORMAT_FLAG: boolean;
 export var API_KEYS: string;
@@ -20,6 +21,7 @@ export var API_BASE_URI: string;
 export function setEnvironment(
   dryRunFlag: boolean,
   addNewFlag: boolean,
+  inviteToAllOrgsFlag: boolean,
   deleteMissingFlag: boolean,
   v2FormatFlag: boolean,
   apiKeys: string,
@@ -28,6 +30,7 @@ export function setEnvironment(
 ) {
   DRY_RUN_FLAG = dryRunFlag;
   ADD_NEW_FLAG = addNewFlag;
+  INVITE_TO_ALL_ORGS_FLAG = inviteToAllOrgsFlag;
   DELETE_MISSING_FLAG = deleteMissingFlag;
   V2_FORMAT_FLAG = v2FormatFlag;
   API_KEYS = apiKeys;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,6 +8,7 @@ import {
   PREV_DIR,
   PENDING_INVITES_FILE,
   DRY_RUN_FLAG,
+  INVITE_TO_ALL_ORGS_FLAG,
   V2_FORMAT_FLAG,
   setEnvironment,
   ADD_NEW_FLAG,
@@ -54,6 +55,10 @@ const argv = yargs
       describe: `print/log the execution plan without making any updates to Snyk`,
       demandOption: false,
     },
+    'invite-to-all-orgs': {
+      describe: `send new users an invite to every org, rather than only the first`,
+      demandOption: false,
+    },
     debug: {
       describe: `enable debug mode`,
       demandOption: false,
@@ -80,6 +85,9 @@ function checkEnvironment() {
     argv['delete-missing'] ? argv['delete-missing'] : false,
   );
   const dryRunFlag = Boolean(argv['dry-run'] ? argv['dry-run'] : false);
+  const inviteToAllOrgsFlag: boolean = Boolean(
+    argv['invite-to-all-orgs'] ? argv['invite-to-all-orgs'] : false,
+  );
   const v2FormatFlag: boolean = Boolean(argv['v2'] ? argv['v2'] : false);
 
   utils.log(`dry run: ${dryRunFlag}`);
@@ -90,6 +98,7 @@ function checkEnvironment() {
   }
   utils.log(`v2 format enabled?: ${v2FormatFlag}`);
   utils.log(`Delete Missing enabled?: ${deleteMissingFlag}`);
+  utils.log(`Invite to all orgs enabled?: ${inviteToAllOrgsFlag}`);
   debug('SNYK_IAM_API_KEYS: ');
   for (const key of snykKeys.split(',')) {
     debug(` ${key}`);
@@ -115,6 +124,7 @@ function checkEnvironment() {
   setEnvironment(
     dryRunFlag,
     addNewFlag,
+    inviteToAllOrgsFlag,
     deleteMissingFlag,
     v2FormatFlag,
     snykKeys,

--- a/src/lib/snykGroup.ts
+++ b/src/lib/snykGroup.ts
@@ -178,7 +178,10 @@ export class snykGroup {
     for (const sm of this._snykMembershipQueue) {
       try {
         await inputUtils.validateUserMembership(sm);
-        if ((await utils.isPendingInvite(sm.userEmail, this.id)) == false) {
+        if (
+          (await utils.isPendingInvite(sm.userEmail, this.id)) == false ||
+          common.INVITE_TO_ALL_ORGS_FLAG
+        ) {
           if ((await this.userExists(sm.userEmail)) == true) {
             //begin user exists in group flow
             const orgId = await this.getOrgIdFromName(sm.org);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Optionally sends an invitation email for every org a is new user needs to be added to.  By default, the tool only sends an invitation email to a new user for the first org we encounter in the input file.  After accepting the initial invite they would be added to all remaining groups on a subsequent job run.  This is done purposely to avoid unnecessary emails and requiring users to click through each of them from their email. However, in some rare cases that may be desired, so we are adding this optional flag.
