### PR TITLE
fix: --save-dev for semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         steps:
             - checkout
             - run: sudo npm install nexe@next -g
-            - run: sudo npm install semantic-release @semantic-release/exec
+            - run: sudo npm install semantic-release @semantic-release/exec --save-dev
             - run: npm install
             - run: npx tsc
             - run: npm run test:unit


### PR DESCRIPTION
- [x ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

adds --save-dev to semantic-release install to avoid getting scanned for issues