### PR TITLE
fix: set default for valid roles when conf/roles.json not present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-user-sync-tool",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "sync snyk org users from an external source",
   "main": "dist/index.js",
   "scripts": {
@@ -30,7 +30,8 @@
   },
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "conf"
   ],
   "homepage": "https://github.com/snyk-tech-services/snyk-user-sync-tool#readme",
   "dependencies": {
@@ -52,6 +53,7 @@
     "jest": "^26.6.3",
     "prettier": "^1.19.1",
     "ts-jest": "^26.5.5",
+    "nexe": "^4.0.0-beta.17",
     "tsc-watch": "^4.1.0",
     "typescript": "^4.2.4"
   },

--- a/src/lib/inputUtils.ts
+++ b/src/lib/inputUtils.ts
@@ -223,8 +223,16 @@ export async function validateUserMembership(snykMembership: {
   org: string;
 }) {
   var reEmail: RegExp = /\S+@\S+\.\S+/;
-  let validRoles: string[] = await readFileToJson(common.VALID_ROLES_FILE);
-
+  // default valid roles
+  let validRoles: string[] = [
+    'admin',
+    'collaborator',
+    'restrictedCollaborator',
+  ];
+  //override default valid roles when conf/roles.json is present
+  if (fs.existsSync(common.VALID_ROLES_FILE)) {
+    let validRoles: string[] = await readFileToJson(common.VALID_ROLES_FILE);
+  }
   if (
     !(
       validRoles


### PR DESCRIPTION
- [x ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

sets default valid roles if conf/roles.json not present


