### PR TITLE
fix: use readline.cursorTo instead of process.stdout.cursorTo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-user-sync-tool",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "sync snyk org users from an external source",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,6 +16,7 @@ import * as common from './common';
 import * as utils from './utils';
 import * as customErrors from './customErrors';
 import { umask } from 'process';
+const readline = require('readline');
 
 const debug = debugLib('snyk:utils');
 const { execSync } = require('child_process');
@@ -92,6 +93,6 @@ export function log(message: string) {
 }
 
 export function printProgress(progress: string) {
-  process.stdout.cursorTo(0);
+  readline.cursorTo(process.stdout, 0)
   process.stdout.write(`${progress}`);
 }


### PR DESCRIPTION
- [ x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

updates use of out-of-date `process.stdout.cursorTo` to `readline.cursorTo` to prevent throwing of error when script is not executed in a TTY environment.

