### PR TITLE
fix: correct invalid .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -71,3 +71,4 @@
     }
   ],
   "branches": ["master"]
+}


### PR DESCRIPTION
### What this does

releaserc was invalid due to missing closing bracket. fixed and verified with `npx semantic-release --dry-run`
