### PR TITLE
chore: remove unneeded version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "snyk-user-sync-tool",
-  "version": "2.2.3",
   "description": "sync snyk org users from an external source",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
`version` is not needed in package.json when using semantic-release