### PR TITLE
fix: use node v12 for all binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    snyk: snyk/snyk@0.0.8
+    snyk: snyk/snyk@1.1.2
 jobs:
     build-test-publish:
         docker:

--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     {
       "//": "build the macos",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe@next dist/index.js -t mac-x64-10.21.0 -o snyk-user-sync-tool-macos"
+      "cmd": "npx nexe@next dist/index.js -t mac-x64-12.16.2 -o snyk-user-sync-tool-macos"
     },
     {
       "//": "build the linux x64",
@@ -24,7 +24,7 @@
     {
       "//": "build the windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npx nexe@next dist/index.js -t windows-x64-10.16.0 -o snyk-user-sync-tool-win.exe"
+      "cmd": "npx nexe@next dist/index.js -t windows-x64-12.16.2 -o snyk-user-sync-tool-win.exe"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
node v10 runtime on binaries produces errors (affecting `macos` and `win` binaries). this change updates the macos and win binary target runtime to v12 to match the others and avoid these errors.

